### PR TITLE
refactor: simplify prelude module to avoid potential name collisions

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -359,7 +359,7 @@ checksum = "349f9b6a179ed607305526ca489b34ad0a41aed5f7980fa90eb03160b69598fb"
 
 [[package]]
 name = "bitbucket-server-rs"
-version = "0.5.0"
+version = "0.5.1"
 dependencies = [
  "chrono",
  "derive_builder",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "bitbucket-server-rs"
 description = "An API client library for Bitbucket Data Center"
-version = "0.5.0"
+version = "0.5.1"
 edition = "2021"
 license-file = "LICENSE"
 repository = "https://github.com/acfabro/bitbucket-server-rs"

--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ Add this to your `Cargo.toml`:
 
 ```toml
 [dependencies]
-bitbucket-server-rs = "0.5.0"
+bitbucket-server-rs = "0.5.1"
 tokio = { version = "1.0", features = ["full"] } # For async runtime
 ```
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -179,16 +179,17 @@
 //!
 //! ## Prelude
 //!
-//! For convenience, you can import everything you need from the prelude module:
+//! For convenience, you can import core functionality from the prelude module:
 //!
 //! ```no_run
 //! use bitbucket_server_rs::prelude::*;
+//! use bitbucket_server_rs::api::build_status_get::BuildStatus;
 //!
 //! #[tokio::main]
 //! async fn main() -> Result<(), Box<dyn std::error::Error>> {
 //!     let client = new("https://bitbucket-server/rest", "API_TOKEN");
 //!
-//!     // Use the client with all the imported types
+//!     // Use the client with explicitly imported API types
 //!     let response = client
 //!         .api()
 //!         .build_status_get("PROJECT", "COMMIT", "REPO")
@@ -211,21 +212,14 @@ pub mod error;
 pub use client::{new, Client, ApiRequest, ApiResponse};
 pub use error::Error;
 
-/// Prelude module that re-exports commonly used types
+/// Prelude module that re-exports core functionality
 ///
-/// This module provides a convenient way to import all commonly used types
+/// This module provides a convenient way to import core types
 /// with a single import statement: `use bitbucket_server_rs::prelude::*;`
+///
+/// Note: Specific API types are not included in the prelude to avoid
+/// potential name collisions. Import those directly from their respective modules.
 pub mod prelude {
     pub use crate::client::{new, Client, ApiRequest, ApiResponse};
     pub use crate::error::Error;
-    
-    // Common API types
-    pub use crate::api::build_status::BuildStatusState;
-    pub use crate::api::build_status::TestResults;
-    pub use crate::api::build_status_get::BuildStatus;
-    pub use crate::api::build_status_post::BuildStatusPostPayload;
-    pub use crate::api::pull_request_changes_get::{PullRequestChanges, ChangeItem, Path};
-    pub use crate::api::pull_request_post::{
-        PullRequestPostPayload, ProjectInfo, RefInfo, RepositoryInfo, Reviewer, User,
-    };
 }


### PR DESCRIPTION
- Remove specific API types from prelude
- Keep only core functionality (new, Client, ApiRequest, ApiResponse, Error)
- Update documentation to clarify prelude usage
- Bump version to 0.5.1